### PR TITLE
0.2.0 candidate

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2015 500px
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -54,18 +54,18 @@ filled in at execution time by a `vars` object passed to the `exec` function.
 
 Gunter defaults to using **ssh-agent** and **agent forwarding** to autheticate
 to a remote host, but you can optionally pass it a username, password and/or
-path to a private key file. You can also pass in a port if you want to user
+path to a private key file. You can also pass in a port if you want to use
 one other than `22` for some reason.
 
 ```json
 {
-  "taskname" : {
-    "remote" : "example.com",
-    "cwd"    : "/",
-    "commands: [
+  "taskname"   : {
+    "remote"   : "example.com",
+    "cwd"      : "/",
+    "commands" : [
       "echo Holla!"
     ],
-    "auth"   : {
+    "auth"     : {
       "username"    : "dudeson",
       "port"        : 22,
       "password"    : "suP3rSekr3tp@$sw0rd",
@@ -170,13 +170,13 @@ understanding of Node callbacks, take a look at
 
 An `EventEmitter` object used by `exec` to asynchronously communicate its state.
 
-Gunter captures and emits all `stdout` from running tasks.  This can be a
-little noisy, so its best to save this for some kind of verbose mode in your
+Gunter captures and emits all `stdout` from running tasks as a buffer.  This can 
+be a little noisy, so its best to save this for some kind of verbose mode in your
 module, or write it to a log file.  You can access it like this:
 ```js
 gunter.emitter.on('stdout', function(data) {
   // Something's been spit out to stdout
-  console.log(data);
+  console.log(data.toString('utf8');
 });
 ```
 
@@ -189,3 +189,30 @@ To learn more about how events work, check out
 + ShellJS for running local commands
 + SSH2 for running remote commands
 + Lo-Dash for not hating my life
+
+## License
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 500px
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+

--- a/README.md
+++ b/README.md
@@ -43,14 +43,44 @@ Tasks are represented as JSON objects, taking the form:
 Notice the [mustache-style](http://mustache.github.io/) variable.  This is
 filled in at execution time by a `vars` object passed to the `exec` function.
 
-+ `remote` tells Gunter where to execute.  This can be either `localhost`, or
-  some arbitrary server.  **Note** that Gunter is currently limited to
-  connecting to a remote through `ssh-agent`, and expects a definition of the
-  form `user@example.host.com`
++ `remote` tells Gunter where to execute (either `localhost`, or some
+  arbitrary server)
 + `cwd` tells Gunter what directory to execute commands in
 + `commands` is an array of commands to execute.  At run time, these will be
   concatenated together with `&&`s in the order in which you define them in
-  the array.
+  the array
+
+## Authentication
+
+Gunter defaults to using **ssh-agent** and **agent forwarding** to autheticate
+to a remote host, but you can optionally pass it a username, password and/or
+path to a private key file. You can also pass in a port if you want to user
+one other than `22` for some reason.
+
+```json
+{
+  "taskname" : {
+    "remote" : "example.com",
+    "cwd"    : "/",
+    "commands: [
+      "echo Holla!"
+    ],
+    "auth"   : {
+      "username"    : "dudeson",
+      "port"        : 22,
+      "password"    : "suP3rSekr3tp@$sw0rd",
+      "privateKey"  : "path/to/private/key"
+    }
+  }
+}
+```
+
+Note that your real password probably shouldn't contain the word "password",
+no matter how creative you are with numbers and symbols.
+
+If several forms of authentication are present, they will be tried in the
+following order until one is successful:
+**Password -> Private Key -> Agent**
 
 ## API
 
@@ -79,12 +109,12 @@ paths may not behave as you expect.
 
 Clears all previously defined tasks from memory.
 
-### .exec(taskname[, vars])
+### .exec(taskname, vars, callback)
 
-The meat and potatoes.  Executes a task.  `exec` is asynchronous, and will emit
-`end` events whenever a task is completed, and `stdout` events whenever the
-shell surfaces some data.  You should make use of the `emitter` object to
-capture these events.
+The meat and potatoes.  Executes a task.  `exec` is asynchronous.  It will emit
+`stdout` events whenever the shell surfaces some data, and you can pass it a
+callback to handle task completion and error.  You should make use of the exported
+`emitter` object to capture the `stdout` events.
 
 #### taskname
 
@@ -96,12 +126,13 @@ The name of the task to execute, as defined in a previously loaded JSON object.
 
 Type: `Object` or `String`
 
-This optional parameter is for filling in variables defined in previously loaded
+This parameter is for filling in variables defined in previously loaded
 JSON tasks.  Like `load`, it accepts either an Object or the path to a JSON
 file.  Here you should pass in keys matching the variable names in your tasks,
-and values containing what they should be replaced by.
+and values containing what they should be replaced by. If you have no variables
+to replace, just pass it an empty object `{}`
 
-Example:
+Example usage:
 ```js
 {
   "name" : "Gunter",
@@ -109,22 +140,39 @@ Example:
 }
 ```
 
+### callback
+
+Type: `Function`
+
+Here you can pass a callback function to execute when `exec` completes.  Gunter
+will call this function in the idiomatic Node style: it will set the first param
+to `nil` and the second to the task object on success, and will set the first
+param to an error message on error.
+
+Your callback should look something like this:
+```js
+function callback(err, task) {
+  if (err) {
+    return console.log(err);
+  }
+
+  // Do something with the task object
+
+  console.log('Task completed successfully!');
+}
+```
+
+It's a good idea to always `return` on `err`.  If you need to brush up on your
+understanding of Node callbacks, take a look at
+[this great tutorial](https://github.com/maxogden/art-of-node#callbacks).
+
 ### .emitter
 
 An `EventEmitter` object used by `exec` to asynchronously communicate its state.
 
-When `exec` executes a task, it will emit `end` events whenever a task is
-completed successfully.  You can capture these events in your module like this:
-```js
-gunter.emitter.on('end', function() {
-  // The task has been completed successfully
-  console.log('Task complete!  Hooray!');
-});
-```
-
-Gunter also captures and emits all `stdout` from running tasks.  This can be a
+Gunter captures and emits all `stdout` from running tasks.  This can be a
 little noisy, so its best to save this for some kind of verbose mode in your
-module.  You can access it like this:
+module, or write it to a log file.  You can access it like this:
 ```js
 gunter.emitter.on('stdout', function(data) {
   // Something's been spit out to stdout

--- a/README.md
+++ b/README.md
@@ -52,10 +52,13 @@ filled in at execution time by a `vars` object passed to the `exec` function.
 
 ## Authentication
 
-Gunter defaults to using **ssh-agent** and **agent forwarding** to autheticate
-to a remote host, but you can optionally pass it a username, password and/or
-path to a private key file. You can also pass in a port if you want to use
-one other than `22` for some reason.
+Gunter supports several authentication strategies (**password**, **private key**, and
+**agent auth**). You can optionally add an `auth` object to your task definitions
+to specify a `username`, `password`, `privateKey`, and `port`.  If you exclude
+some or all of these parameters, Gunter will use agent authentication, on port
+22, and set the username to the executing user's username.
+
+Here's an example of a task definition that includes an `auth` object:
 
 ```json
 {

--- a/lib/clear.js
+++ b/lib/clear.js
@@ -2,5 +2,5 @@
 
 // Public
 module.exports = function clear() {
-  global.taskList = {}
-}
+  global.taskList = {};
+};

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,41 +1,50 @@
 'use strict';
 var _ = require('lodash');
-var errors = require('./helpers/errors');
 var variables = require('./helpers/variables');
 var emitter = require('./emitter');
 var shell = require('shelljs');
+var fs = require('fs');
 
 // Public
-module.exports = function exec(taskname, vars) {
-  errors.checkString(taskname, 'taskname must be a string');
-  errors.checkNonEmpty(taskname, 'taskname must be non-empty');
-
-  var task = getTask(taskname);
-  if (!(_.isUndefined(vars))) {
-    task = variables.processVars(task, vars);
+module.exports = function exec(taskname, vars, callback) {
+  if (!(_.isString(taskname))) {
+    return callback('taskname must be a string');
   }
 
-  execTask(task, taskResponse);
-}
+  if (_.isEmpty(taskname)) {
+    return callback('taskname must be non-empty');
+  }
 
+  var task = global.taskList[taskname];
+  if (_.isUndefined(task)) {
+    return callback(taskname + ' is not defined');
+  }
+
+  if (!(_.isObject(vars)) && !(_.isString(vars))) {
+    return callback('vars must be a String or an Object');
+  }
+
+  if (!(_.isEmpty(vars))) {
+    try {
+      task = variables.processVars(task, vars);
+    } catch(err) {
+      return callback(err);
+    }
+  }
+
+  remoteOrLocal(task, callback);
+}
 
 // Private
-function getTask(taskname) {
-  var task = global.taskList[taskname];
-  errors.checkDefined(task, taskname + ' is not defined');
-
-  return task;
-}
-
-function execTask(task, callback) {
+function remoteOrLocal(task, callback) {
   if (task.remote == 'localhost') {
-    localTask(task, callback);
+    local(task, callback);
   } else {
-    remoteTask(task, callback);
+    remote(task, callback);
   }
 }
 
-function localTask(task, callback) {
+function local(task, callback) {
   var commands = concatCommands(task.cwd, task.commands);
 
   try {
@@ -52,14 +61,15 @@ function localTask(task, callback) {
   }
 }
 
-function remoteTask(task, callback) {
+function remote(task, callback) {
   var Client = require('ssh2').Client;
   var conn = new Client();
-  var remoteSplit = task.remote.split('@');
-  var user = remoteSplit[0];
-  var remote = remoteSplit[1];
-
   var commands = concatCommands(task.cwd, task.commands);
+  var auth = {};
+
+  if (task.auth.password) { auth = passwordAuth(task); }
+  else if (task.auth.privateKey) { auth = privateKeyAuth(task); }
+  else { auth = agentAuth(task); }
 
   conn.on('ready', function(){
     conn.exec(commands, { agentForward: true }, function(err, stream){
@@ -74,13 +84,35 @@ function remoteTask(task, callback) {
         return callback(data);
       });
     });
-  }).connect({
-    host: remote,
-    port: 22,
-    username: user,
+  }).connect(auth);
+}
+
+function passwordAuth(task) {
+  return {
+    host: task.remote,
+    port: task.auth.port || 22,
+    username: task.auth.username,
+    password: task.auth.password
+  };
+}
+
+function privateKeyAuth(task) {
+  return {
+    host: task.remote,
+    port: task.auth.port || 22,
+    username: task.auth.username,
+    privateKey: fs.readFileSync(task.auth.privateKey)
+  };
+}
+
+function agentAuth(task) {
+  return {
+    host: task.remote,
+    port: task.auth.port || 22,
+    username: task.auth.username,
     agent: process.env.SSH_AUTH_SOCK,
     agentForward: true
-  });
+  };
 }
 
 function concatCommands(cwd, commands) {
@@ -93,9 +125,3 @@ function concatCommands(cwd, commands) {
   return concat;
 }
 
-function taskResponse(err, task) {
-  if (err){
-    throw new Error(err);
-  }
-  emitter.emit('end');
-}

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -65,25 +65,31 @@ function remote(task, callback) {
   var Client = require('ssh2').Client;
   var conn = new Client();
   var commands = concatCommands(task.cwd, task.commands);
-  var auth = {};
-  var agentForward = false;
 
-  if (task.auth && task.auth.password) {
-    auth = passwordAuth(task);
-  } else if (task.auth && task.auth.privateKey) {
+  // Setup auth
+  var auth = {
+    host: task.remote,
+    agent: process.env.SSH_AUTH_SOCK,
+    agentForward: true,
+  };
+
+  if (task.auth && task.auth.port) { auth.port = task.auth.port; }
+  else { auth.port = 22; }
+
+  if (task.auth && task.auth.username) { auth.username = task.auth.username; }
+  else { auth.username = process.env.USER; }
+
+  if (task.auth && task.auth.password) { auth.password = task.auth.password; }
+  if (task.auth && task.auth.privateKey) {
     try {
-      var privateKey = fs.readFileSync(task.auth.privateKey)
+      auth.privateKey = fs.readFileSync(task.auth.privateKey);
     } catch(err) {
       return callback(err);
     }
-    auth = privateKeyAuth(task, privateKey);
-  } else {
-    agentForward = true;
-    auth = agentAuth(task);
   }
 
   conn.on('ready', function(){
-    conn.exec(commands, { agentForward: agentForward }, function(err, stream){
+    conn.exec(commands, function(err, stream){
       if (err) return callback(err);
       stream.on('close', function(code, signal) {
         if (code !== 0) return callback('ERROR: Exit status ' + code);
@@ -98,42 +104,6 @@ function remote(task, callback) {
   }).on('error', function(err) {
     return callback(err);
   }).connect(auth);
-}
-
-function passwordAuth(task) {
-  return {
-    host: task.remote,
-    port: task.auth.port || 22,
-    username: task.auth.username || process.env.USER,
-    password: task.auth.password,
-  };
-}
-
-function privateKeyAuth(task, privateKey) {
-  return {
-    host: task.remote,
-    port: task.auth.port || 22,
-    username: task.auth.username || process.env.USER,
-    privateKey: privateKey,
-  };
-}
-
-function agentAuth(task) {
-  var auth = {
-    host: task.remote,
-    agent: process.env.SSH_AUTH_SOCK,
-    agentForward: true,
-  };
-
-  if (task.auth) {
-    auth.port = task.auth.port || 22;
-    auth.username = task.auth.username || process.env.USER;
-  } else {
-    auth.port = 22;
-    auth.username = process.env.USER;
-  }
-
-  return auth;
 }
 
 function concatCommands(cwd, commands) {

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -33,7 +33,7 @@ module.exports = function exec(taskname, vars, callback) {
   }
 
   remoteOrLocal(task, callback);
-}
+};
 
 // Private
 function remoteOrLocal(task, callback) {
@@ -49,7 +49,7 @@ function local(task, callback) {
 
   try {
     var child = shell.exec(commands, {async:true}, function(code, output){
-      if (code != 0) return callback(output);
+      if (code !== 0) return callback(output);
       return callback(null, task);
     });
 
@@ -67,15 +67,15 @@ function remote(task, callback) {
   var commands = concatCommands(task.cwd, task.commands);
   var auth = {};
 
-  if (task.auth.password) { auth = passwordAuth(task); }
-  else if (task.auth.privateKey) { auth = privateKeyAuth(task); }
+  if (task.auth && task.auth.password) { auth = passwordAuth(task); }
+  else if (task.auth && task.auth.privateKey) { auth = privateKeyAuth(task); }
   else { auth = agentAuth(task); }
 
   conn.on('ready', function(){
     conn.exec(commands, { agentForward: true }, function(err, stream){
       if (err) return callback(err);
       stream.on('close', function(code, signal) {
-        if (code != 0) return callback('ERROR: Exit status ' + code);
+        if (code !== 0) return callback('ERROR: Exit status ' + code);
         conn.end();
         return callback(null, task);
       }).on('data', function(data) {
@@ -84,6 +84,8 @@ function remote(task, callback) {
         return callback(data);
       });
     });
+  }).on('error', function(err) {
+    return callback(err);
   }).connect(auth);
 }
 
@@ -91,7 +93,7 @@ function passwordAuth(task) {
   return {
     host: task.remote,
     port: task.auth.port || 22,
-    username: task.auth.username,
+    username: task.auth.username || process.env.USER,
     password: task.auth.password
   };
 }
@@ -100,19 +102,27 @@ function privateKeyAuth(task) {
   return {
     host: task.remote,
     port: task.auth.port || 22,
-    username: task.auth.username,
+    username: task.auth.username || process.env.USER,
     privateKey: fs.readFileSync(task.auth.privateKey)
   };
 }
 
 function agentAuth(task) {
-  return {
+  var auth = {
     host: task.remote,
-    port: task.auth.port || 22,
-    username: task.auth.username,
     agent: process.env.SSH_AUTH_SOCK,
-    agentForward: true
+    agentForward: true,
   };
+
+  if (task.auth) {
+    auth.port = task.auth.port || 22;
+    auth.username = task.auth.username || process.env.USER;
+  } else {
+    auth.port = 22;
+    auth.username = process.env.USER;
+  }
+
+  return auth;
 }
 
 function concatCommands(cwd, commands) {

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -66,13 +66,24 @@ function remote(task, callback) {
   var conn = new Client();
   var commands = concatCommands(task.cwd, task.commands);
   var auth = {};
+  var agentForward = false;
 
-  if (task.auth && task.auth.password) { auth = passwordAuth(task); }
-  else if (task.auth && task.auth.privateKey) { auth = privateKeyAuth(task); }
-  else { auth = agentAuth(task); }
+  if (task.auth && task.auth.password) {
+    auth = passwordAuth(task);
+  } else if (task.auth && task.auth.privateKey) {
+    try {
+      var privateKey = fs.readFileSync(task.auth.privateKey)
+    } catch(err) {
+      return callback(err);
+    }
+    auth = privateKeyAuth(task, privateKey);
+  } else {
+    agentForward = true;
+    auth = agentAuth(task);
+  }
 
   conn.on('ready', function(){
-    conn.exec(commands, { agentForward: true }, function(err, stream){
+    conn.exec(commands, { agentForward: agentForward }, function(err, stream){
       if (err) return callback(err);
       stream.on('close', function(code, signal) {
         if (code !== 0) return callback('ERROR: Exit status ' + code);
@@ -94,16 +105,16 @@ function passwordAuth(task) {
     host: task.remote,
     port: task.auth.port || 22,
     username: task.auth.username || process.env.USER,
-    password: task.auth.password
+    password: task.auth.password,
   };
 }
 
-function privateKeyAuth(task) {
+function privateKeyAuth(task, privateKey) {
   return {
     host: task.remote,
     port: task.auth.port || 22,
     username: task.auth.username || process.env.USER,
-    privateKey: fs.readFileSync(task.auth.privateKey)
+    privateKey: privateKey,
   };
 }
 

--- a/lib/gunter.js
+++ b/lib/gunter.js
@@ -8,4 +8,4 @@ module.exports = {
   clear: require('./clear'),
   exec: require('./exec'),
   emitter: require('./emitter')
-}
+};

--- a/lib/helpers/errors.js
+++ b/lib/helpers/errors.js
@@ -26,4 +26,4 @@ module.exports = {
       throw new Error(message);
     }
   }
-}
+};

--- a/lib/helpers/variables.js
+++ b/lib/helpers/variables.js
@@ -12,7 +12,7 @@ module.exports = {
       throw new Error('vars only accepts a JSON Object or a String filepath');
     }
   }
-}
+};
 
 
 // Private

--- a/lib/load.js
+++ b/lib/load.js
@@ -11,7 +11,7 @@ module.exports = function load(tasks) {
   } else {
     throw new Error('load only accepts a JSON Object or a String filepath');
   }
-}
+};
 
 
 // Private

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gunter",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "license": "MIT",
   "description": "Language agnostic task wrapper",
   "author": "500px",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "node": ">= 0.10.0"
   },
   "devDependencies": {
-    "mocha": "^2.1.0",
-    "should": "^4.6.5"
+    "mocha": "^2.2.1",
+    "should": "^5.2.0"
   },
   "dependencies": {
     "lodash": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "lodash": "^3.1.0",
-    "shelljs": "^0.3.0",
+    "shelljs": "^0.4.0",
     "ssh2": "^0.4.3"
   }
 }

--- a/test/lib/clear.js
+++ b/test/lib/clear.js
@@ -3,7 +3,7 @@ var clear = require('../../lib/clear');
 
 describe('clear', function(){
   it('clears the global taskList', function(){
-    global.taskList = { 'name' : 'Gunter' }
+    global.taskList = { 'name' : 'Gunter' };
     clear();
     global.taskList.should.be.empty;
   });

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -12,7 +12,7 @@ describe('exec', function(){
           "echo {{cool}}!"
         ]
       }
-    }
+    };
   });
 
   afterEach(function(){
@@ -58,7 +58,7 @@ describe('exec', function(){
                   "echo {{cool}}!"
                 ]
               }
-            }
+            };
           });
 
           // Connection refused, I should find a way to stub this
@@ -106,7 +106,7 @@ describe('exec', function(){
       describe('when the path is invalid', function(){
         it('returns an error', function(){
           exec('task', 'wenk', function(err, task) {
-            err.should.not.be.Nil;
+            err.should.not.be.null;
           });
         });
       });
@@ -115,7 +115,7 @@ describe('exec', function(){
     describe('when vars are neither an Object nor a String path', function(){
       it('returns an error', function(){
         exec('task', 1, function(err, task) {
-          err.should.not.be.Nil;
+          err.should.not.be.null;
         });
       });
     });

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -41,23 +41,14 @@ describe('exec', function(){
 
       describe('when task is defined', function(){
         describe('when remote is localhost', function(){
-          it('executes the commands locally', function(done){
-            var out = [];
-
-            emitter.on('stdout', function(data) {
-              out.push(data);
+          it('executes locally', function(){
+            exec('task', {}, function(err, task) {
+              task.should.not.be.empty.and.containEql({ commands: [ 'echo {{cool}}!' ], cwd: '.', remote: 'localhost' });
             });
-
-            emitter.on('end', function(){
-              out.should.not.be.empty.and.containEql('{{cool}}!\n');
-              done();
-            });
-
-            exec('task');
           });
         });
 
-        describe('when remote is some server', function(){
+        xdescribe('when remote is some server', function(){
           beforeEach(function(){
             global.taskList = {
               task: {
@@ -71,19 +62,10 @@ describe('exec', function(){
           });
 
           // Connection refused, I should find a way to stub this
-          xit('executes the commands on the server', function(){
-            var out = [];
-
-            emitter.on('stdout', function(data) {
-              out.push(data);
+          it('executes the commands on the server', function(){
+            exec('task', {}, function(err, task){
+              task.should.not.be.empty.and.containEql({ commands: [ 'echo {{cool}}!' ], cwd: '.', remote: 'localhost' });
             });
-
-            emitter.on('end', function(){
-              out.should.not.be.empty.and.containEql('{{cool}}!\n');
-              done();
-            });
-
-            exec('task');
           });
         });
       });
@@ -93,19 +75,18 @@ describe('exec', function(){
   describe('when passed vars', function(){
     describe('when vars are an Object', function(){
       describe('when vars match variables in the task', function(){
-        it('replaces the variables with values in var', function(done){
-          var out = [];
-
-          emitter.on('stdout', function(data) {
-            out.push(data);
+        it('replaces the variables with values in var', function(){
+          exec('task', { cool: 'fool' }, function(err, task) {
+            task.should.not.be.empty.and.containEql({ commands: [ 'echo fool!' ], cwd: '.', remote: 'localhost' });
           });
+        });
+      });
 
-          emitter.on('end', function(){
-            out.should.not.be.empty.and.containEql('fool!\n');
-            done();
+      describe('when vars does not match variables in the task', function() {
+        it('executes normally', function(){
+          exec('task', { wenk: 'wenk' }, function(err, task) {
+            task.should.not.be.empty.and.containEql({ commands: [ 'echo {{cool}}!' ], cwd: '.', remote: 'localhost' });
           });
-
-          exec('task', { cool: 'fool' });
         });
       });
     });
@@ -113,34 +94,29 @@ describe('exec', function(){
     describe('when vars are a String path', function(){
       describe('when the path is valid', function(){
         describe('when vars match variables in the task', function(){
-          it('replaces the variables with values in file', function(done){
-            var out = [];
-
-            emitter.on('stdout', function(data) {
-              out.push(data);
-            });
-
-            emitter.on('end', function(){
-              out.should.not.be.empty.and.containEql('fool!\n');
-              done();
-            });
-
+          it('replaces the variables with values in file', function(){
             var filepath = '../../test/fixtures/exec/valid-vars.json';
-            exec('task', filepath);
+            exec('task', filepath, function(err, task) {
+              task.should.not.be.empty.and.eql({ commands: [ 'echo fool!' ], cwd: '.', remote: 'localhost' });
+            });
           });
         });
       });
 
       describe('when the path is invalid', function(){
-        it('throws an error', function(){
-          exec.bind(null, 'task', 'wenk').should.throw();
+        it('returns an error', function(){
+          exec('task', 'wenk', function(err, task) {
+            err.should.not.be.Nil;
+          });
         });
       });
     });
 
     describe('when vars are neither an Object nor a String path', function(){
-      it('throws an error', function(){
-        exec.bind(null, 'task', 1).should.throw();
+      it('returns an error', function(){
+        exec('task', 1, function(err, task) {
+          err.should.not.be.Nil;
+        });
       });
     });
   });

--- a/test/lib/helpers/variables.js
+++ b/test/lib/helpers/variables.js
@@ -8,7 +8,7 @@ describe('variables', function(){
     commands: [
       "echo {{cool}}!"
     ]
-  }
+  };
 
   describe('processVars', function(){
     it('should be defined', function(){
@@ -40,7 +40,7 @@ describe('variables', function(){
               "echo {{cool}}!"
             ]
           }
-        }
+        };
         variables.processVars(global.taskList.task, { cool: 'fool' });
         global.taskList.task.commands[0].should.equal("echo {{cool}}!");
       });
@@ -52,7 +52,7 @@ describe('variables', function(){
           commands: [
             "echo cool!"
           ]
-        }
+        };
 
         it('should not throw an error', function(){
           variables.processVars.bind(null, task, { cool: 'fool' }).should.not.throw();

--- a/test/lib/load.js
+++ b/test/lib/load.js
@@ -3,8 +3,8 @@ var load = require('../../lib/load');
 
 describe('load', function(){
   beforeEach(function(){
-    global.taskList = {}
-  })
+    global.taskList = {};
+  });
 
   describe('when passed an object', function(){
     describe('when object is valid', function(){
@@ -18,7 +18,7 @@ describe('load', function(){
             "echo Hello, my name is {{name}}"
           ]
         }
-      }
+      };
 
       it('adds the tasks to the global taskList', function(){
         load(tasks);
@@ -46,7 +46,7 @@ describe('load', function(){
             "echo Hello, my name is {{name}}"
           ]
         }
-      }
+      };
 
       it('throws an error', function(){
         load.bind(null, tasks).should.throw();
@@ -63,7 +63,7 @@ describe('load', function(){
             "echo Hello, my name is {{name}}"
           ]
         }
-      }
+      };
 
       it('throws an error', function(){
         load.bind(null, tasks).should.throw();
@@ -76,7 +76,7 @@ describe('load', function(){
           remote: "localhost",
           cwd: "/"
         }
-      }
+      };
 
       it('throws an error', function(){
         load.bind(null, tasks).should.throw();
@@ -94,7 +94,7 @@ describe('load', function(){
             command3: "echo Hello, my name is {{name}}"
           }
         }
-      }
+      };
 
       it('throws an error', function(){
         load.bind(null, tasks).should.throw();
@@ -122,7 +122,7 @@ describe('load', function(){
               "echo Hello, my name is {{name}}"
             ]
           }
-        }
+        };
 
         it('adds the tasks to the global taskList', function(){
           load(tasks);
@@ -164,7 +164,7 @@ describe('load', function(){
             remote: "localhost",
             cwd: "/"
           }
-        }
+        };
 
         it('throws an error', function(){
           load.bind(null, tasks).should.throw();
@@ -184,7 +184,7 @@ describe('load', function(){
               "echo Hello, my name is {{name}}"
             ]
           }
-        }
+        };
 
         var tasks = {
           task2: {
@@ -194,7 +194,7 @@ describe('load', function(){
               "echo I'm a task!"
             ]
           }
-        }
+        };
 
         load(tasks);
 
@@ -226,7 +226,7 @@ describe('load', function(){
         var filepath = '../test/fixtures/load/valid.json';
 
         it('adds the tasks to the global taskList', function(){
-          load(filepath)
+          load(filepath);
           global.taskList.should.containEql({
             "task1" : {
               "remote" : "localhost",


### PR DESCRIPTION
Solves #15 

Changes `exec` to expect a callback, à la the `dev` branch.  Also adds support for various authentication methods (username/password, private key auth, and agent auth), and bumps versions for [shelljs](https://www.npmjs.com/package/shelljs), [should](https://www.npmjs.com/package/should) and [mocha](https://www.npmjs.com/package/mocha).

We should probably test the various auth methods, and test how `ssh2` handles receiving, say, a blank `username`.  I wrote this under the assumption that it'll just eat any `undefined` variables its passed, but that might not be the case.

@pwyliu Check it out.