### PR TITLE
Support defaults for variables in task definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,31 @@ var gunter = require('gunter');
 
 ## Defining Tasks
 
-Tasks are represented as JSON objects, taking the form:
+Tasks are represented as JSON objects.  Here is a basic task:
+```json
+{
+  "taskname" : {
+    "remote" : "localhost",
+    "cwd" : "/",
+    "commands" : [
+      "echo I'm a task!",
+      "echo I'm another task!",
+      "echo Hello, my name is Gunter!"
+    ]
+  }
+}
+```
+
++ `remote` tells Gunter where to execute (either `localhost`, or some
+  arbitrary server)
++ `cwd` tells Gunter what directory to execute commands in
++ `commands` is an array of commands to execute.  At run time, these will be
+  concatenated together with `&&`s in the order in which you define them in
+  the array
+
+## Variables
+
+Take a look at this task definition:
 ```json
 {
   "taskname" : {
@@ -36,19 +60,21 @@ Tasks are represented as JSON objects, taking the form:
       "echo I'm a task!",
       "echo I'm another task!",
       "echo Hello, my name is {{name}}"
-    ]
+    ],
+    "defaults" : {
+      "name" : "Gunter"
+    }
   }
 }
 ```
-Notice the [mustache-style](http://mustache.github.io/) variable.  This is
-filled in at execution time by a `vars` object passed to the `exec` function.
 
-+ `remote` tells Gunter where to execute (either `localhost`, or some
-  arbitrary server)
-+ `cwd` tells Gunter what directory to execute commands in
-+ `commands` is an array of commands to execute.  At run time, these will be
-  concatenated together with `&&`s in the order in which you define them in
-  the array
+There are a couple differences from the one in [Defining Tasks](#defining-tasks).
+Notice the [mustache-style](http://mustache.github.io/) variable `{{name}}`.  This
+is filled in at execution time by a `vars` object passed to the `exec` function.
+You can also optionally include a `defaults` object in your task definition if
+you'd like to have defaults set for your variables, in case you don't pass anything
+in to `exec`.  Otherwise, these variables will default to an empty string.
+
 
 ## Authentication
 
@@ -133,7 +159,8 @@ This parameter is for filling in variables defined in previously loaded
 JSON tasks.  Like `load`, it accepts either an Object or the path to a JSON
 file.  Here you should pass in keys matching the variable names in your tasks,
 and values containing what they should be replaced by. If you have no variables
-to replace, just pass it an empty object `{}`
+to replace, just pass it an empty object `{}`.  Note that any variables you pass
+in here that aren't actually defined in your task will just get eaten at runtime.
 
 Example usage:
 ```js
@@ -173,7 +200,7 @@ understanding of Node callbacks, take a look at
 
 An `EventEmitter` object used by `exec` to asynchronously communicate its state.
 
-Gunter captures and emits all `stdout` from running tasks as a buffer.  This can 
+Gunter captures and emits all `stdout` from running tasks as a buffer.  This can
 be a little noisy, so its best to save this for some kind of verbose mode in your
 module, or write it to a log file.  You can access it like this:
 ```js
@@ -218,4 +245,3 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
-

--- a/lib/helpers/variables.js
+++ b/lib/helpers/variables.js
@@ -17,19 +17,34 @@ module.exports = {
 
 // Private
 function replaceVars(task, vars) {
-  var processedTask = _.cloneDeep(task);
+  var taskClone = _.cloneDeep(task);
+
+  // Handle vars object
+  taskClone = doWork(taskClone, vars);
+
+  // Handle defaults
+  if (taskClone['defaults']) {
+    taskClone = doWork(taskClone, taskClone['defaults']);
+  }
+
+  return taskClone;
+}
+
+function doWork(task, vars) {
   for (var i = 0; i < Object.keys(vars).length; i++) {
     var key = Object.keys(vars)[i];
-    for (var j = 0; j < processedTask.commands.length; j++) {
-      var command = processedTask.commands[j];
-      var mutatedCommand = command.replace("{{" + key + "}}", vars[key]);
-      if (mutatedCommand != command) {
-        processedTask.commands[j] = mutatedCommand;
+    if (vars[key]) {
+      for (var j = 0; j < task.commands.length; j++) {
+        var command = task.commands[j];
+        var mutatedCommand = command.replace("{{" + key + "}}", vars[key]);
+        if (mutatedCommand != command) {
+          task.commands[j] = mutatedCommand;
+        }
       }
     }
   }
 
-  return processedTask;
+  return task;
 }
 
 function parseJsonFile(task, file) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gunter",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "license": "MIT",
   "description": "Language agnostic task wrapper",
   "author": "500px",
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "mocha": "^2.2.1",
-    "should": "^5.2.0"
+    "should": "^6.0.1"
   },
   "dependencies": {
     "lodash": "^3.1.0",

--- a/test/lib/helpers/variables.js
+++ b/test/lib/helpers/variables.js
@@ -99,5 +99,66 @@ describe('variables', function(){
         variables.processVars.bind(null, task, 2).should.throw();
       });
     });
+
+    describe('when defaults are set in the task', function(){
+      var taskDefaults = {
+        remote: "localhost",
+        cwd: "../test",
+        commands: [
+          "echo {{cool}}!"
+        ],
+        defaults: {
+          cool: "tool"
+        }
+      };
+
+      describe('when variable is defined in task, but not passed in', function(){
+        it('replaces the variable with the default value', function(){
+          var result = variables.processVars(taskDefaults, {});
+          result.should.containEql({
+            remote: "localhost",
+            cwd: "../test",
+            commands: [
+              "echo tool!"
+            ],
+            defaults: {
+              cool: "tool"
+            }
+          });
+        });
+      });
+
+      describe('when vars object contains empty variables', function(){
+        it('should replace the var with the default', function(){
+          var result = variables.processVars(taskDefaults, { cool: '' });
+          result.should.containEql({
+            remote: "localhost",
+            cwd: "../test",
+            commands: [
+              "echo tool!"
+            ],
+            defaults: {
+              cool: "tool"
+            }
+          });
+        });
+      });
+
+      describe('when vars object contains valid vars', function(){
+        it('should replace the var with passed in var, not the default', function(){
+          var result = variables.processVars(taskDefaults, { cool: 'fool' });
+          result.should.containEql({
+            remote: "localhost",
+            cwd: "../test",
+            commands: [
+              "echo fool!"
+            ],
+            defaults: {
+              cool: "tool"
+            }
+          });
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
@pwyliu This is something I've run into several times now that's annoyed me; expecting the client to set defaults at execution time for task variables.  I think it probably makes more sense to allow clients to optionally set defaults for variables in the task definition.  We also probably shouldn't be replacing variables with empty values like an empty string or `undefined`, so I've handled that here as well.