### PR TITLE
0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Wenk.
 Language agnostic task wrapper and loyal servant.  Runs arbitrary shell commands
 in an arbitrary working directory on an arbitrary server.
 
+[Upgrading from 0.3.x to 0.4.x](https://github.com/500px/gunter/wiki/Upgrading-from-0.3.x-to-0.4.x)
+
 ## Usage
 
 Gunter requires you to define a set of tasks, represented as JSON, which tell
@@ -138,18 +140,30 @@ paths may not behave as you expect.
 
 Clears all previously defined tasks from memory.
 
-### .exec(taskname, vars, callback)
+### .exec(taskname, event, vars, callback)
 
 The meat and potatoes.  Executes a task.  `exec` is asynchronous.  It will emit
-`stdout` events whenever the shell surfaces some data, and you can pass it a
-callback to handle task completion and error.  You should make use of the exported
-`emitter` object to capture the `stdout` events.
+events against the `event` tag whenever the shell surfaces some data, and you can
+pass it a callback to handle task completion and error.  You should make use of
+the exported `emitter` object to capture the `stdout` events.
 
 #### taskname
 
 Type: `String`
 
 The name of the task to execute, as defined in a previously loaded JSON object.
+
+#### event
+
+Type: `String`
+
+Tells Gunter what event to emit on `stdout`.  If you leave this value `null`, it'll
+default to emitting on the `'stdout'` event.  Make sure you set up an event listener
+for the event passed here as described in [.emitter](#-emitter) below before calling
+this function.
+
+**Important note**: If you'll be running more than one task concurrently, you'll
+probably want to give each a unique event you can monitor.
 
 #### vars
 
@@ -202,9 +216,16 @@ An `EventEmitter` object used by `exec` to asynchronously communicate its state.
 
 Gunter captures and emits all `stdout` from running tasks as a buffer.  This can
 be a little noisy, so its best to save this for some kind of verbose mode in your
-module, or write it to a log file.  You can access it like this:
+module, or write it to a log file.  
+
+How you should access these events depends on how you'll be calling `exec`.  If
+you're going to pass `exec` an `event`, setup a listener for that event.  If you're
+not concerned about concurrency, aren't passing a value to `event`, and want
+everything to report on one event, setup a listener for the default event, `'stdout'`
+
+You can access it like this:
 ```js
-gunter.emitter.on('stdout', function(data) {
+gunter.emitter.on('eventName', function(data) {
   // Something's been spit out to stdout
   console.log(data.toString('utf8');
 });

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Clears all previously defined tasks from memory.
 The meat and potatoes.  Executes a task.  `exec` is asynchronous.  It will emit
 events against the `event` tag whenever the shell surfaces some data, and you can
 pass it a callback to handle task completion and error.  You should make use of
-the exported `emitter` object to capture the `stdout` events.
+the exported `emitter` object to capture the `output` events.
 
 #### taskname
 
@@ -157,10 +157,10 @@ The name of the task to execute, as defined in a previously loaded JSON object.
 
 Type: `String`
 
-Tells Gunter what event to emit on `stdout`.  If you leave this value `null`, it'll
-default to emitting on the `'stdout'` event.  Make sure you set up an event listener
-for the event passed here as described in [.emitter](#-emitter) below before calling
-this function.
+Tells Gunter what event to emit on `output` (`stdout` and `stderr`).  If you
+leave this value `null`, it'll default to emitting on the `'output'` event.  Make
+sure you set up an event listener for the event passed here as described in
+[.emitter](#-emitter) below before calling this function.
 
 **Important note**: If you'll be running more than one task concurrently, you'll
 probably want to give each a unique event you can monitor.
@@ -214,19 +214,19 @@ understanding of Node callbacks, take a look at
 
 An `EventEmitter` object used by `exec` to asynchronously communicate its state.
 
-Gunter captures and emits all `stdout` from running tasks as a buffer.  This can
+Gunter captures and emits all output from running tasks as a buffer.  This can
 be a little noisy, so its best to save this for some kind of verbose mode in your
 module, or write it to a log file.  
 
 How you should access these events depends on how you'll be calling `exec`.  If
 you're going to pass `exec` an `event`, setup a listener for that event.  If you're
 not concerned about concurrency, aren't passing a value to `event`, and want
-everything to report on one event, setup a listener for the default event, `'stdout'`
+everything to report on one event, setup a listener for the default event, `'output'`
 
 You can access it like this:
 ```js
 gunter.emitter.on('eventName', function(data) {
-  // Something's been spit out to stdout
+  // Something's been spit out
   console.log(data.toString('utf8');
 });
 ```

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -28,7 +28,7 @@ module.exports = function exec(taskname, eventName, vars, callback) {
     }
   }
 
-  if (_.isEmpty(eventName)) {
+  if (_.isNull(eventName)) {
     eventName = 'stdout';
   } else if (!(_.isString(eventName))) {
     return callback('event must be a string');
@@ -130,4 +130,3 @@ function concatCommands(cwd, commands) {
 
   return concat;
 }
-

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -6,13 +6,9 @@ var shell = require('shelljs');
 var fs = require('fs');
 
 // Public
-module.exports = function exec(taskname, vars, callback) {
-  if (!(_.isString(taskname))) {
-    return callback('taskname must be a string');
-  }
-
-  if (_.isEmpty(taskname)) {
-    return callback('taskname must be non-empty');
+module.exports = function exec(taskname, eventName, vars, callback) {
+  if (!(_.isString(taskname)) || _.isEmpty(taskname)) {
+    return callback('taskname must be a non-empty string');
   }
 
   var task = global.taskList[taskname];
@@ -32,19 +28,25 @@ module.exports = function exec(taskname, vars, callback) {
     }
   }
 
-  remoteOrLocal(task, callback);
+  if (_.isEmpty(eventName)) {
+    eventName = 'stdout';
+  } else if (!(_.isString(eventName))) {
+    return callback('event must be a string');
+  }
+
+  remoteOrLocal(task, eventName, callback);
 };
 
 // Private
-function remoteOrLocal(task, callback) {
+function remoteOrLocal(task, eventName, callback) {
   if (task.remote == 'localhost') {
-    local(task, callback);
+    local(task, eventName, callback);
   } else {
-    remote(task, callback);
+    remote(task, eventName, callback);
   }
 }
 
-function local(task, callback) {
+function local(task, eventName, callback) {
   var commands = concatCommands(task.cwd, task.commands);
 
   try {
@@ -54,14 +56,14 @@ function local(task, callback) {
     });
 
     child.stdout.on('data', function(data){
-      emitter.emit('stdout', data);
+      emitter.emit(eventName, data);
     });
   } catch(err) {
     return callback(err);
   }
 }
 
-function remote(task, callback) {
+function remote(task, eventName, callback) {
   var Client = require('ssh2').Client;
   var conn = new Client();
   var commands = concatCommands(task.cwd, task.commands);
@@ -106,7 +108,7 @@ function remote(task, callback) {
           conn.end();
           return callback(null, task);
         }).on('data', function(data) {
-          emitter.emit('stdout', data);
+          emitter.emit(eventName, data);
         }).stderr.on('data', function(data) {
           return callback(data);
         });

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -29,7 +29,7 @@ module.exports = function exec(taskname, eventName, vars, callback) {
   }
 
   if (_.isNull(eventName)) {
-    eventName = 'stdout';
+    eventName = 'output';
   } else if (!(_.isString(eventName))) {
     return callback('event must be a string');
   }
@@ -67,6 +67,7 @@ function remote(task, eventName, callback) {
   var Client = require('ssh2').Client;
   var conn = new Client();
   var commands = concatCommands(task.cwd, task.commands);
+  var stderr = '';
 
   // Setup auth
   var auth = {
@@ -104,13 +105,15 @@ function remote(task, eventName, callback) {
       conn.exec(commands, function(err, stream){
         if (err) return callback(err);
         stream.on('close', function(code, signal) {
-          if (code !== 0) return callback('ERROR: Exit status ' + code);
           conn.end();
+          if (!_.isEmpty(stderr)) return callback(stderr);
+          if (code !== 0) return callback('ERROR: Exit status ' + code);
           return callback(null, task);
         }).on('data', function(data) {
           emitter.emit(eventName, data);
         }).stderr.on('data', function(data) {
-          return callback(data);
+          stderr = stderr + data;
+          emitter.emit(eventName, data);
         });
       });
     }).on('error', function(err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gunter",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "Language agnostic task wrapper",
   "author": "500px",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "lodash": "^3.9.3",
-    "shelljs": "^0.5.0",
+    "shelljs": "^0.5.1",
     "ssh2": "^0.4.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "node": ">= 0.10.0"
   },
   "devDependencies": {
-    "mocha": "^2.2.1",
-    "should": "^6.0.1"
+    "mocha": "^2.2.5",
+    "should": "^6.0.3"
   },
   "dependencies": {
-    "lodash": "^3.1.0",
-    "shelljs": "^0.4.0",
-    "ssh2": "^0.4.3"
+    "lodash": "^3.9.3",
+    "shelljs": "^0.5.0",
+    "ssh2": "^0.4.8"
   }
 }

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -19,30 +19,36 @@ describe('exec', function(){
     emitter.removeAllListeners();
   });
 
-  describe('when passed only a name', function(){
+  describe('name', function(){
     describe('when name is not a String', function(){
-      it('throws an error', function(){
-        exec.bind(null, 1).should.throw();
+      it('returns an error', function(){
+        exec(1, null, {}, function(err, task){
+          err.should.not.be.null;
+        });
       });
     });
 
     describe('when name is an empty String', function(){
-      it('throws an error', function(){
-        exec.bind(null, '').should.throw();
+      it('returns an error', function(){
+        exec('', null, {}, function(err, task){
+          err.should.not.be.null;
+        });
       });
     });
 
     describe('when name is well formed', function(){
       describe('when task is not defined', function(){
-        it('throws an error', function(){
-          exec.bind(null,'wenk').should.throw();
+        it('returns an error', function(){
+          exec('wenk', null, {}, function(err, task){
+            err.should.not.be.null;
+          });
         });
       });
 
       describe('when task is defined', function(){
         describe('when remote is localhost', function(){
           it('executes locally', function(){
-            exec('task', {}, function(err, task) {
+            exec('task', null, {}, function(err, task) {
               task.should.not.be.empty.and.containEql({ commands: [ 'echo {{cool}}!' ], cwd: '.', remote: 'localhost' });
             });
           });
@@ -63,7 +69,7 @@ describe('exec', function(){
 
           // Connection refused, I should find a way to stub this
           it('executes the commands on the server', function(){
-            exec('task', {}, function(err, task){
+            exec('task', null, {}, function(err, task){
               task.should.not.be.empty.and.containEql({ commands: [ 'echo {{cool}}!' ], cwd: '.', remote: 'localhost' });
             });
           });

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -76,7 +76,7 @@ describe('exec', function(){
     describe('when vars are an Object', function(){
       describe('when vars match variables in the task', function(){
         it('replaces the variables with values in var', function(){
-          exec('task', { cool: 'fool' }, function(err, task) {
+          exec('task', null, { cool: 'fool' }, function(err, task) {
             task.should.not.be.empty.and.containEql({ commands: [ 'echo fool!' ], cwd: '.', remote: 'localhost' });
           });
         });
@@ -84,7 +84,7 @@ describe('exec', function(){
 
       describe('when vars does not match variables in the task', function() {
         it('executes normally', function(){
-          exec('task', { wenk: 'wenk' }, function(err, task) {
+          exec('task', null, { wenk: 'wenk' }, function(err, task) {
             task.should.not.be.empty.and.containEql({ commands: [ 'echo {{cool}}!' ], cwd: '.', remote: 'localhost' });
           });
         });
@@ -96,7 +96,7 @@ describe('exec', function(){
         describe('when vars match variables in the task', function(){
           it('replaces the variables with values in file', function(){
             var filepath = '../../test/fixtures/exec/valid-vars.json';
-            exec('task', filepath, function(err, task) {
+            exec('task', null, filepath, function(err, task) {
               task.should.not.be.empty.and.eql({ commands: [ 'echo fool!' ], cwd: '.', remote: 'localhost' });
             });
           });
@@ -105,7 +105,7 @@ describe('exec', function(){
 
       describe('when the path is invalid', function(){
         it('returns an error', function(){
-          exec('task', 'wenk', function(err, task) {
+          exec('task', null, 'wenk', function(err, task) {
             err.should.not.be.null;
           });
         });
@@ -114,7 +114,57 @@ describe('exec', function(){
 
     describe('when vars are neither an Object nor a String path', function(){
       it('returns an error', function(){
-        exec('task', 1, function(err, task) {
+        exec('task', null, 1, function(err, task) {
+          err.should.not.be.null;
+        });
+      });
+    });
+  });
+
+  describe('event name', function(){
+    describe('when event is a String', function(){
+      it('emits on the event passed and not stdout', function(){
+        var test = '';
+        var stdout = '';
+
+        emitter.on('test', function(data) {
+          test = test + data;
+        });
+
+        emitter.on('stdout', function(data) {
+          stdout = stdout + data;
+        });
+
+        exec('task', 'test', {}, function(err, task) {
+          test.should.not.be.empty;
+          stdout.should.be.empty;
+        });
+      });
+    });
+
+    describe('when event is null', function(){
+      it('emits on the default stdout event', function(){
+        var test = '';
+        var stdout = '';
+
+        emitter.on('test', function(data) {
+          test = test + data;
+        });
+
+        emitter.on('stdout', function(data) {
+          stdout = stdout + data;
+        });
+
+        exec('task', null, {}, function(err, task) {
+          test.should.be.empty;
+          stdout.should.not.be.empty;
+        });
+      });
+    });
+
+    describe('when event is neither a String nor null', function(){
+      it('returns an error', function(){
+        exec('task', 1, {}, function(err, task) {
           err.should.not.be.null;
         });
       });

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -129,41 +129,41 @@ describe('exec', function(){
 
   describe('event name', function(){
     describe('when event is a String', function(){
-      it('emits on the event passed and not stdout', function(){
+      it('emits on the event passed and not output', function(){
         var test = '';
-        var stdout = '';
+        var output = '';
 
         emitter.on('test', function(data) {
           test = test + data;
         });
 
-        emitter.on('stdout', function(data) {
-          stdout = stdout + data;
+        emitter.on('output', function(data) {
+          output = output + data;
         });
 
         exec('task', 'test', {}, function(err, task) {
           test.should.not.be.empty;
-          stdout.should.be.empty;
+          output.should.be.empty;
         });
       });
     });
 
     describe('when event is null', function(){
-      it('emits on the default stdout event', function(){
+      it('emits on the default output event', function(){
         var test = '';
-        var stdout = '';
+        var output = '';
 
         emitter.on('test', function(data) {
           test = test + data;
         });
 
-        emitter.on('stdout', function(data) {
-          stdout = stdout + data;
+        emitter.on('output', function(data) {
+          output = output + data;
         });
 
         exec('task', null, {}, function(err, task) {
           test.should.be.empty;
-          stdout.should.not.be.empty;
+          output.should.not.be.empty;
         });
       });
     });


### PR DESCRIPTION
Allows clients to pass `exec` a custom event name to emit `stdout` on.  Event name will default to `'stdout'` if the event name is left `null`.

Will require a small change to how existing clients call `exec`, so I've linked to a (yet to be written) upgrade guide at the top of the README as well.